### PR TITLE
switch to ASP.NET Core FrameworkReference

### DIFF
--- a/examples/Imageflow.Net.Server.Example/Imageflow.Net.Server.Example.csproj
+++ b/examples/Imageflow.Net.Server.Example/Imageflow.Net.Server.Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..\src</DockerfileContext>
   </PropertyGroup>

--- a/src/Imageflow.Net.Server/Imageflow.Net.Server.csproj
+++ b/src/Imageflow.Net.Server/Imageflow.Net.Server.csproj
@@ -1,18 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Imageflow.Server</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Imageflow.Net" Version="0.4.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />
+  <ItemGroup>    
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />    
+    <PackageReference Include="Imageflow.Net" Version="0.4.4" />    
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
For: https://github.com/imazen/imageflow-dotnet-server/issues/2

Use post-2.2 ASP.NET Core which now requires `netcoreapp3.1` but transparently bundles all needed dependencies.