### PR TITLE
Correctly reference blob name

### DIFF
--- a/src/Imageflow.Server.Storage.AzureBlob/AzureBlobService.cs
+++ b/src/Imageflow.Server.Storage.AzureBlob/AzureBlobService.cs
@@ -49,11 +49,11 @@ namespace Imageflow.Server.Storage.AzureBlob
             }
 
             var mapping = mappings[prefix];
-            var key = mapping.UrlPrefix + virtualPath.Substring(prefix.Length);
+            var blobName = virtualPath.Substring(prefix.Length);
 
             try
             {
-                var blobClient = client.GetBlobContainerClient(mapping.Container).GetBlobClient(key);
+                var blobClient = client.GetBlobContainerClient(mapping.Container).GetBlobClient(blobName);
 
                 var s = await blobClient.DownloadAsync();
                 return new AzureBlob(s);


### PR DESCRIPTION
I see the azure configuration has changed to expect a container. 

At first I was a bit confused as to how I would do this, as we use multiple containers for different sets of images. In the end I came up with the following that I think should work:

```
// Make Azure container available at / azure
services.AddImageflowAzureBlobService(
	new AzureBlobServiceOptions(
			"UseDevelopmentStorage=true;",
			new BlobClientOptions())
		.MapPrefix("/azure/team", "team"));
```

Alas, the blob is not found (throws a FileNotFoundException) when I make the following request
https://localhost:44376/azure/team/123.jpg

Looking at the code in AzureBlobService, I think there may just be a typo here.