### PR TITLE
Increase the size of the example image so the watermark is applied

### DIFF
--- a/examples/Imageflow.Server.Example/Views/Home/Index.cshtml
+++ b/examples/Imageflow.Server.Example/Views/Home/Index.cshtml
@@ -17,7 +17,7 @@
 
 
 <h2> Test watermarking</h2>
-<img srcset="/images/fire-umbrella-small.jpg?width=300&watermark=imazen,
+<img srcset="/images/fire-umbrella-small.jpg?width=350&watermark=imazen,
              /images/fire-umbrella-small.jpg?width=450&watermark=imazen 1.5x,
              /images/fire-umbrella-small.jpg?watermark=imazen 2x"
      src="~/images/fire-umbrella-small.jpg" alt="fire umbrella" />


### PR DESCRIPTION
This may be a regression bug. At a glance, I would have expected the watermark to be rendered with an image size of 300px wide with the example settings, and seem to remember seeing it rendered previously. Of course happy to discard this PR if that's the case :)