### PR TITLE
Make mapped virtual path's case insensitive

### DIFF
--- a/src/Imageflow.Server/BlobProvider.cs
+++ b/src/Imageflow.Server/BlobProvider.cs
@@ -61,7 +61,7 @@ namespace Imageflow.Server
         internal BlobProviderResult? GetFileResult(string virtualPath)
         {
             var mapping = pathMappings.FirstOrDefault(
-                m => virtualPath.StartsWith(m.VirtualPath, StringComparison.Ordinal));
+                m => virtualPath.StartsWith(m.VirtualPath, StringComparison.OrdinalIgnoreCase));
             if (mapping.PhysicalPath == null || mapping.VirtualPath == null) return null;
 
             var relativePath = virtualPath

--- a/src/Imageflow.Server/BlobProvider.cs
+++ b/src/Imageflow.Server/BlobProvider.cs
@@ -61,7 +61,7 @@ namespace Imageflow.Server
         internal BlobProviderResult? GetFileResult(string virtualPath)
         {
             var mapping = pathMappings.FirstOrDefault(
-                m => virtualPath.StartsWith(m.VirtualPath, StringComparison.OrdinalIgnoreCase));
+                m => virtualPath.StartsWith(m.VirtualPath, m.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal));
             if (mapping.PhysicalPath == null || mapping.VirtualPath == null) return null;
 
             var relativePath = virtualPath

--- a/src/Imageflow.Server/ImageflowMiddlewareOptions.cs
+++ b/src/Imageflow.Server/ImageflowMiddlewareOptions.cs
@@ -110,9 +110,9 @@ namespace Imageflow.Server
         }
 
 
-        public ImageflowMiddlewareOptions MapPath(string virtualPath, string physicalPath)
+        public ImageflowMiddlewareOptions MapPath(string virtualPath, string physicalPath, bool ignoreCase = false)
         {
-            mappedPaths.Add(new PathMapping(virtualPath,physicalPath));
+            mappedPaths.Add(new PathMapping(virtualPath, physicalPath, ignoreCase));
             return this;
         }
         public ImageflowMiddlewareOptions AddWatermark(NamedWatermark watermark)

--- a/src/Imageflow.Server/PathMapping.cs
+++ b/src/Imageflow.Server/PathMapping.cs
@@ -2,12 +2,15 @@ namespace Imageflow.Server
 {
     public struct PathMapping
     {
-        public PathMapping(string virtualPath, string physicalPath)
+        public PathMapping(string virtualPath, string physicalPath, bool ignoreCase = false)
         {
             VirtualPath = virtualPath;
             PhysicalPath = physicalPath.TrimEnd('/','\\');
+            IgnoreCase = ignoreCase;
         }
+
         public string VirtualPath { get; }
         public string PhysicalPath { get; }
+        public bool IgnoreCase { get; }
     }
 }


### PR DESCRIPTION
Noticed when using "MapPath" that the path seems to be case sensitive, when it shouldn't be:

                app.UseImageflow(new ImageflowMiddlewareOptions()
                    .SetMapWebRoot(false)
                    .MapPath("/vehicle", Path.Combine(dir, @"Inventory\Vehicle"))
                );

Calls like "https://localhost:44315/Vehicle/image.jpg?width=101" won't work because of the capital "V" in the virtual path. Changing it to a lowercase "v" will then produce the image. Should work either way or at least be configurable.

Note that this code change is untested, so you may need to verify it.