### PR TITLE
Use IHttpClientFactory - Breaking Changes

### DIFF
--- a/examples/Imageflow.Server.Example/Imageflow.Server.Example.csproj
+++ b/examples/Imageflow.Server.Example/Imageflow.Server.Example.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Imageflow.Server.DiskCache\Imageflow.Server.DiskCache.csproj" />
     <ProjectReference Include="..\..\src\Imageflow.Server.SqliteCache\Imageflow.Server.SqliteCache.csproj" />
     <ProjectReference Include="..\..\src\Imageflow.Server.Storage.AzureBlob\Imageflow.Server.Storage.AzureBlob.csproj" />

--- a/examples/Imageflow.Server.Example/Startup.cs
+++ b/examples/Imageflow.Server.Example/Startup.cs
@@ -33,24 +33,8 @@ namespace Imageflow.Server.Example
         {
             services.AddControllersWithViews();
 
-            services.AddHttpClient("TrickyHttpClient", config =>
-            {
-                config.DefaultRequestHeaders.Add("user-agent", "Tricky Client");
-                config.DefaultRequestHeaders.Add("authorization", "secret");
-            });
-
-            services.AddHttpClient(nameof(RemoteReaderService), config =>
-            {
-                config.DefaultRequestHeaders.Add("user-agent", "ImageFlow-DotNet-Server");
-
-            }).ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
-            {
-                AllowAutoRedirect = true,
-                MaxAutomaticRedirections = 50
-
-            }).AddTransientHttpErrorPolicy(builder => builder
-                .RetryAsync()
-            );
+            // See the README for more advanced configuration
+            services.AddHttpClient();
 
             var remoteReaderServiceOptions = new RemoteReaderServiceOptions
             {
@@ -58,14 +42,8 @@ namespace Imageflow.Server.Example
             }
             .AddPrefix("/remote/");
 
-            services.AddImageflowRemoteReaderService(remoteReaderServiceOptions, uri =>
-            {
-                return uri.Host switch
-                {
-                    "tricky.endpoint.local" => "TrickyHttpClient",
-                    _ => nameof(RemoteReaderService)
-                };
-            });
+            services.AddImageflowRemoteReaderService(remoteReaderServiceOptions);
+
 
             // Make S3 containers available at /ri/ and /imageflow-resources/
             // If you use credentials, do not check them into your repository

--- a/src/Imageflow.Server.Storage.RemoteReader/Imageflow.Server.Storage.RemoteReader.csproj
+++ b/src/Imageflow.Server.Storage.RemoteReader/Imageflow.Server.Storage.RemoteReader.csproj
@@ -16,6 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Imageflow.Server\Imageflow.Server.csproj" />
     <ProjectReference Include="..\Imazen.Common\Imazen.Common.csproj" />
   </ItemGroup>

--- a/src/Imageflow.Server.Storage.RemoteReader/README.md
+++ b/src/Imageflow.Server.Storage.RemoteReader/README.md
@@ -34,7 +34,7 @@ To use the "named" client we configured above, configure a simple selector that 
 ```
 
 ## Add a Retry Policy for Transient Errors 
-Add the `Microsoft.Extensions.Http.Polly` nuget package to your project
+Adding the `Microsoft.Extensions.Http.Polly` nuget package to your project will make available the Polly ClientBuilderExtensions.
 ```
     services.AddHttpClient(nameof(RemoteReaderService))
         .AddTransientHttpErrorPolicy(builder => builder.RetryAsync());
@@ -47,8 +47,8 @@ Add the `Microsoft.Extensions.Http.Polly` nuget package to your project
     .AddPrefix("/remote/");
 ```
 
-## Endpoint-Specific Configuration
-The `HttpClientSelector` accepts a uri and is expected to retun the name of a configured http client.
+## Host-Specific Configuration
+The `HttpClientSelector` accepts a uri and is expected to retun the name of a configured http client. This simple example shows how you could add an `authorization` header for a specific remote host.
 ```
     services.AddHttpClient("TrickyHttpClient", config =>
     {

--- a/src/Imageflow.Server.Storage.RemoteReader/README.md
+++ b/src/Imageflow.Server.Storage.RemoteReader/README.md
@@ -1,0 +1,74 @@
+﻿
+
+
+
+## Basic Configuration
+```
+    services.AddHttpClient();
+
+    var remoteReaderServiceOptions = new RemoteReaderServiceOptions
+    {
+        SigningKey = "ChangeMe"
+    }
+    .AddPrefix("/remote/");
+
+    services.AddImageflowRemoteReaderService(remoteReaderServiceOptions);
+```
+
+## Add Custom Headers
+To configure the client to send custom headers, we need to use an overload of `AddHttpClient()` that returns an `IHttpClientBuilder`.
+```
+    services.AddHttpClient("ImageFlow-DotNet-Server", config =>
+    {
+        config.DefaultRequestHeaders.Add("user-agent", "ImageFlow-DotNet-Server");
+    });
+```
+To use the "named" client we configured above, configure a simple selector that returns its name.
+```
+    var remoteReaderServiceOptions = new RemoteReaderServiceOptions
+    {
+        SigningKey = "ChangeMe",
+        HttpClientSelector = _ => "ImageFlow-DotNet-Server"
+    }
+    .AddPrefix("/remote/");
+```
+
+## Add a Retry Policy for Transient Errors 
+Add the `Microsoft.Extensions.Http.Polly` nuget package to your project
+```
+    services.AddHttpClient(nameof(RemoteReaderService))
+        .AddTransientHttpErrorPolicy(builder => builder.RetryAsync());
+
+    var remoteReaderServiceOptions = new RemoteReaderServiceOptions
+    {
+        SigningKey = "ChangeMe",
+        HttpClientSelector = _ => nameof(RemoteReaderService)
+    }
+    .AddPrefix("/remote/");
+```
+
+## Endpoint-Specific Configuration
+The `HttpClientSelector` accepts a uri and is expected to retun the name of a configured http client.
+```
+    services.AddHttpClient("TrickyHttpClient", config =>
+    {
+        config.DefaultRequestHeaders.Add("user-agent", "Tricky Client");
+        config.DefaultRequestHeaders.Add("authorization", "secret");
+    });
+
+    var remoteReaderServiceOptions = new RemoteReaderServiceOptions
+    {
+        SigningKey = "ChangeMe",
+        HttpClientSelector = uri =>
+        {
+            return uri.Host switch
+            {
+                "tricky.endpoint.local" => "TrickyHttpClient",
+                _ => nameof(RemoteReaderService)
+            };
+        }
+    }
+    .AddPrefix("/remote/");
+
+
+``` 

--- a/src/Imageflow.Server.Storage.RemoteReader/README.md
+++ b/src/Imageflow.Server.Storage.RemoteReader/README.md
@@ -33,6 +33,26 @@ To use the "named" client we configured above, configure a simple selector that 
     .AddPrefix("/remote/");
 ```
 
+## Limiting Redirects 
+The `RemoteReaderServiceOptions.RedirectLimit` has been removed in favour of configuring the `HttpClientHandler` directly. 
+```
+    services.AddHttpClient(nameof(RemoteReaderService))
+    .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+        {
+            AllowAutoRedirect = true,
+            MaxAutomaticRedirections = 10
+
+        });
+
+    var remoteReaderServiceOptions = new RemoteReaderServiceOptions
+    {
+        SigningKey = "ChangeMe",
+        HttpClientSelector = _ => nameof(RemoteReaderService)
+    }
+    .AddPrefix("/remote/");
+```
+
+
 ## Add a Retry Policy for Transient Errors 
 Adding the `Microsoft.Extensions.Http.Polly` nuget package to your project will make available the Polly ClientBuilderExtensions.
 ```

--- a/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderService.cs
+++ b/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderService.cs
@@ -1,4 +1,5 @@
-﻿using Imazen.Common.Storage;
+﻿using Imazen.Common.Helpers;
+using Imazen.Common.Storage;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -6,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Imazen.Common.Helpers;
 
 namespace Imageflow.Server.Storage.RemoteReader
 {
@@ -14,21 +14,34 @@ namespace Imageflow.Server.Storage.RemoteReader
     {
 
         private readonly List<string> prefixes = new List<string>();
-        private readonly HttpClient http;
+        private readonly IHttpClientFactory httpFactory;
         private readonly RemoteReaderServiceOptions options;
-        // ReSharper disable once NotAccessedField.Local
         private readonly ILogger<RemoteReaderService> logger;
 
-        public RemoteReaderService(RemoteReaderServiceOptions options, ILogger<RemoteReaderService> logger)
+        private Func<Uri, string> HttpClientSelector;
+
+        public RemoteReaderService(RemoteReaderServiceOptions options
+            , Func<Uri, string> httpClientSelector
+            , ILogger<RemoteReaderService> logger
+            , IHttpClientFactory httpFactory
+            ) : this(options, logger, httpFactory)
+        {
+            HttpClientSelector = httpClientSelector;
+        }
+
+        public RemoteReaderService(RemoteReaderServiceOptions options
+            , ILogger<RemoteReaderService> logger
+            , IHttpClientFactory httpFactory
+            )
         {
             this.options = options;
             this.logger = logger;
+            this.httpFactory = httpFactory;
+            HttpClientSelector = (_) => "";
 
             prefixes.AddRange(this.options.Prefixes);
             prefixes.Sort((a, b) => b.Length.CompareTo(a.Length));
 
-            http = new HttpClient();
-            http.DefaultRequestHeaders.Add("user-agent", this.options.UserAgent);
         }
 
         /// <summary>
@@ -42,42 +55,56 @@ namespace Imageflow.Server.Storage.RemoteReader
         {
             var remote = virtualPath
                 .Split('/')
-                .Last()
+                .Last()?
                 .Split('.');
+
+            if (remote == null || remote.Length < 2)
+            {
+                logger.LogWarning("Invalid remote path: {VirtualPath}", virtualPath);
+                throw new BlobMissingException($"Invalid remote path: {virtualPath}");
+            }
 
             var urlBase64 = remote[0];
             var hmac = remote[1];
             var sig = Signatures.SignString(urlBase64, options.SigningKey, 8);
 
             if (hmac != sig)
+            {
+                logger.LogWarning("Missing or Invalid signature on remote path: {VirtualPath}", virtualPath);
                 throw new BlobMissingException($"Missing or Invalid signature on remote path: {virtualPath}");
+            }
 
             var url = EncodingUtils.FromBase64UToString(urlBase64);
+
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            {
+                logger.LogWarning("RemoteReader blob \"{VirtualPath}\" not found. Invalid Uri: {Url}", virtualPath, url);
+                throw new BlobMissingException($"RemoteReader blob \"{virtualPath}\" not found. Invalid Uri: {url}");
+            }
+
+            var httpClientName = HttpClientSelector(uri);
+            using var http = httpFactory.CreateClient(httpClientName);
 
             try
             {
                 var resp = await http.GetAsync(url);
 
-                var redirectCount = 0;
-
-                while (resp.StatusCode == System.Net.HttpStatusCode.Redirect
-                    && redirectCount++ < options.RedirectLimit
-                    && resp.Headers.Location != null
-                    )
-                {
-                    resp = await http.GetAsync(resp.Headers.Location);
-                }
-
                 if (!resp.IsSuccessStatusCode)
                 {
-                    throw new BlobMissingException($"RemoteReader blob \"{virtualPath}\" not found.");
+                    logger.LogWarning("RemoteReader blob \"{VirtualPath}\" not found. The remote \"{Url}\" responded with status: {StatusCode}", virtualPath, url, resp.StatusCode);
+                    throw new BlobMissingException($"RemoteReader blob \"{virtualPath}\" not found. The remote \"{url}\" responded with status: {resp.StatusCode}");
                 }
 
                 return new RemoteReaderBlob(resp);
             }
+            catch (BlobMissingException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
-                throw new BlobMissingException($"RemoteReader blob error retrieving \"{virtualPath}\" .", ex);
+                logger.LogWarning(ex, "RemoteReader blob error retrieving \"{Url}\" for \"{VirtualPath}\".", url, virtualPath);
+                throw new BlobMissingException($"RemoteReader blob error retrieving \"{url}\" for \"{virtualPath}\".", ex);
             }
         }
 
@@ -102,7 +129,5 @@ namespace Imageflow.Server.Storage.RemoteReader
             var sig = Signatures.SignString(data, key,8);
             return $"{data}.{sig}.{sanitizedExtension}";
         }
-
-
     }
 }

--- a/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderService.cs
+++ b/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderService.cs
@@ -17,17 +17,7 @@ namespace Imageflow.Server.Storage.RemoteReader
         private readonly IHttpClientFactory httpFactory;
         private readonly RemoteReaderServiceOptions options;
         private readonly ILogger<RemoteReaderService> logger;
-
-        private Func<Uri, string> HttpClientSelector;
-
-        public RemoteReaderService(RemoteReaderServiceOptions options
-            , Func<Uri, string> httpClientSelector
-            , ILogger<RemoteReaderService> logger
-            , IHttpClientFactory httpFactory
-            ) : this(options, logger, httpFactory)
-        {
-            HttpClientSelector = httpClientSelector;
-        }
+        private readonly Func<Uri, string> httpClientSelector;
 
         public RemoteReaderService(RemoteReaderServiceOptions options
             , ILogger<RemoteReaderService> logger
@@ -37,11 +27,10 @@ namespace Imageflow.Server.Storage.RemoteReader
             this.options = options;
             this.logger = logger;
             this.httpFactory = httpFactory;
-            HttpClientSelector = (_) => "";
+            httpClientSelector = options.HttpClientSelector ?? (_ => "");
 
             prefixes.AddRange(this.options.Prefixes);
             prefixes.Sort((a, b) => b.Length.CompareTo(a.Length));
-
         }
 
         /// <summary>
@@ -60,7 +49,7 @@ namespace Imageflow.Server.Storage.RemoteReader
 
             if (remote == null || remote.Length < 2)
             {
-                logger.LogWarning("Invalid remote path: {VirtualPath}", virtualPath);
+                logger?.LogWarning("Invalid remote path: {VirtualPath}", virtualPath);
                 throw new BlobMissingException($"Invalid remote path: {virtualPath}");
             }
 
@@ -70,7 +59,7 @@ namespace Imageflow.Server.Storage.RemoteReader
 
             if (hmac != sig)
             {
-                logger.LogWarning("Missing or Invalid signature on remote path: {VirtualPath}", virtualPath);
+                logger?.LogWarning("Missing or Invalid signature on remote path: {VirtualPath}", virtualPath);
                 throw new BlobMissingException($"Missing or Invalid signature on remote path: {virtualPath}");
             }
 
@@ -78,11 +67,11 @@ namespace Imageflow.Server.Storage.RemoteReader
 
             if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
             {
-                logger.LogWarning("RemoteReader blob {VirtualPath} not found. Invalid Uri: {Url}", virtualPath, url);
+                logger?.LogWarning("RemoteReader blob {VirtualPath} not found. Invalid Uri: {Url}", virtualPath, url);
                 throw new BlobMissingException($"RemoteReader blob \"{virtualPath}\" not found. Invalid Uri: {url}");
             }
 
-            var httpClientName = HttpClientSelector(uri);
+            var httpClientName = httpClientSelector(uri);
             using var http = httpFactory.CreateClient(httpClientName);
 
             try
@@ -91,7 +80,7 @@ namespace Imageflow.Server.Storage.RemoteReader
 
                 if (!resp.IsSuccessStatusCode)
                 {
-                    logger.LogWarning("RemoteReader blob {VirtualPath} not found. The remote {Url} responded with status: {StatusCode}", virtualPath, url, resp.StatusCode);
+                    logger?.LogWarning("RemoteReader blob {VirtualPath} not found. The remote {Url} responded with status: {StatusCode}", virtualPath, url, resp.StatusCode);
                     throw new BlobMissingException($"RemoteReader blob \"{virtualPath}\" not found. The remote \"{url}\" responded with status: {resp.StatusCode}");
                 }
 
@@ -103,7 +92,7 @@ namespace Imageflow.Server.Storage.RemoteReader
             }
             catch (Exception ex)
             {
-                logger.LogWarning(ex, "RemoteReader blob error retrieving {Url} for {VirtualPath}.", url, virtualPath);
+                logger?.LogWarning(ex, "RemoteReader blob error retrieving {Url} for {VirtualPath}.", url, virtualPath);
                 throw new BlobMissingException($"RemoteReader blob error retrieving \"{url}\" for \"{virtualPath}\".", ex);
             }
         }

--- a/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderService.cs
+++ b/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderService.cs
@@ -78,7 +78,7 @@ namespace Imageflow.Server.Storage.RemoteReader
 
             if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
             {
-                logger.LogWarning("RemoteReader blob \"{VirtualPath}\" not found. Invalid Uri: {Url}", virtualPath, url);
+                logger.LogWarning("RemoteReader blob {VirtualPath} not found. Invalid Uri: {Url}", virtualPath, url);
                 throw new BlobMissingException($"RemoteReader blob \"{virtualPath}\" not found. Invalid Uri: {url}");
             }
 
@@ -91,7 +91,7 @@ namespace Imageflow.Server.Storage.RemoteReader
 
                 if (!resp.IsSuccessStatusCode)
                 {
-                    logger.LogWarning("RemoteReader blob \"{VirtualPath}\" not found. The remote \"{Url}\" responded with status: {StatusCode}", virtualPath, url, resp.StatusCode);
+                    logger.LogWarning("RemoteReader blob {VirtualPath} not found. The remote {Url} responded with status: {StatusCode}", virtualPath, url, resp.StatusCode);
                     throw new BlobMissingException($"RemoteReader blob \"{virtualPath}\" not found. The remote \"{url}\" responded with status: {resp.StatusCode}");
                 }
 
@@ -103,7 +103,7 @@ namespace Imageflow.Server.Storage.RemoteReader
             }
             catch (Exception ex)
             {
-                logger.LogWarning(ex, "RemoteReader blob error retrieving \"{Url}\" for \"{VirtualPath}\".", url, virtualPath);
+                logger.LogWarning(ex, "RemoteReader blob error retrieving {Url} for {VirtualPath}.", url, virtualPath);
                 throw new BlobMissingException($"RemoteReader blob error retrieving \"{url}\" for \"{virtualPath}\".", ex);
             }
         }

--- a/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderServiceExtensions.cs
+++ b/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderServiceExtensions.cs
@@ -1,21 +1,41 @@
 ﻿using Imazen.Common.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Http;
 
 namespace Imageflow.Server.Storage.RemoteReader
 {
     public static class RemoteReaderServiceExtensions
     {
-        public static IServiceCollection AddImageflowRemoteReaderService(this IServiceCollection services,
-    RemoteReaderServiceOptions options)
+        public static IServiceCollection AddImageflowRemoteReaderService(this IServiceCollection services
+            , RemoteReaderServiceOptions options
+            )
         {
             services.AddSingleton<IBlobProvider>((container) =>
             {
                 var logger = container.GetRequiredService<ILogger<RemoteReaderService>>();
-                return new RemoteReaderService(options, logger);
+                var http = container.GetRequiredService<IHttpClientFactory>();
+                return new RemoteReaderService(options, logger, http);
             });
 
             return services;
         }
+
+        public static IServiceCollection AddImageflowRemoteReaderService(this IServiceCollection services
+            , RemoteReaderServiceOptions options
+            , Func<Uri, string> httpClientSelector
+            )
+        {
+            services.AddSingleton<IBlobProvider>((container) =>
+            {
+                var logger = container.GetRequiredService<ILogger<RemoteReaderService>>();
+                var http = container.GetRequiredService<IHttpClientFactory>();
+                return new RemoteReaderService(options, httpClientSelector, logger, http);
+            });
+
+            return services;
+        }
+
     }
 }

--- a/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderServiceExtensions.cs
+++ b/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderServiceExtensions.cs
@@ -21,21 +21,5 @@ namespace Imageflow.Server.Storage.RemoteReader
 
             return services;
         }
-
-        public static IServiceCollection AddImageflowRemoteReaderService(this IServiceCollection services
-            , RemoteReaderServiceOptions options
-            , Func<Uri, string> httpClientSelector
-            )
-        {
-            services.AddSingleton<IBlobProvider>((container) =>
-            {
-                var logger = container.GetRequiredService<ILogger<RemoteReaderService>>();
-                var http = container.GetRequiredService<IHttpClientFactory>();
-                return new RemoteReaderService(options, httpClientSelector, logger, http);
-            });
-
-            return services;
-        }
-
     }
 }

--- a/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderServiceOptions.cs
+++ b/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderServiceOptions.cs
@@ -1,17 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Imageflow.Server.Storage.RemoteReader
 {
     public class RemoteReaderServiceOptions
     {
         internal readonly List<string> Prefixes = new List<string>();
-
-        public int RedirectLimit { get; set; } = 5;
         public string SigningKey { get; set; }
-        public string UserAgent { get; set; } = "ImageFlow-DotNet-Server";
-        
         public bool IgnorePrefixCase { get; set; }
 
         public RemoteReaderServiceOptions AddPrefix(string prefix)

--- a/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderServiceOptions.cs
+++ b/src/Imageflow.Server.Storage.RemoteReader/RemoteReaderServiceOptions.cs
@@ -9,6 +9,8 @@ namespace Imageflow.Server.Storage.RemoteReader
         public string SigningKey { get; set; }
         public bool IgnorePrefixCase { get; set; }
 
+        public Func<Uri, string> HttpClientSelector { get; set; } = _ => "";
+
         public RemoteReaderServiceOptions AddPrefix(string prefix)
         {
             prefix = prefix.TrimStart('/').TrimEnd('/');


### PR DESCRIPTION
Use `IHttpClientFactory` with named clients
Expose a client selector delegate allowing use of different `HttpMessageHandler` for different remote hosts
Remove unnecessary config params
Demonstrate optional use of Polly (no dependency)
Add logging

With this PR, the `RemoteReader` will no longer follow redirects from `https` => `http`.  Redirect handling is now left to the `HttpClientHandler.AllowAutoRedirect` property of the configured handler, and for security reasons `https` => `http` is disallowed.  I'm looking for a way to handle this with `Polly` in the event it is needed.