### PR TITLE
Add ClientFactory overload to S3 plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ namespace Imageflow.Server.Example
             // You can call AddImageflowS3Service multiple times for each unique access key
             services.AddImageflowS3Service(new S3ServiceOptions( null,null)
                 .MapPrefix("/ri/", RegionEndpoint.USEast1, "resizer-images")
-                .MapPrefix("/imageflow-resources/", RegionEndpoint.USWest2, "imageflow-resources"));
+                .MapPrefix("/imageflow-resources/", RegionEndpoint.USWest2, "imageflow-resources")
+                .MapPrefix("/custom-s3client/", () => new AmazonS3Client(), "custom-client", "", false, false)
+            );
             
             // Make Azure container available at /azure
             // You can call AddImageflowAzureBlobService multiple times for each connection string

--- a/examples/Imageflow.Server.Example/Startup.cs
+++ b/examples/Imageflow.Server.Example/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.IO;
+using Amazon.S3;
 using Imageflow.Server.HybridCache;
 
 namespace Imageflow.Server.Example
@@ -45,7 +46,9 @@ namespace Imageflow.Server.Example
             // You can call AddImageflowS3Service multiple times for each unique access key
             services.AddImageflowS3Service(new S3ServiceOptions( null,null)
                 .MapPrefix("/ri/", RegionEndpoint.USEast1, "resizer-images")
-                .MapPrefix("/imageflow-resources/", RegionEndpoint.USWest2, "imageflow-resources"));
+                .MapPrefix("/imageflow-resources/", RegionEndpoint.USWest2, "imageflow-resources")
+                .MapPrefix("/custom-s3client/", () => new AmazonS3Client(), "custom-client", "", false, false)
+            );
             
             // Make Azure container available at /azure
             // You can call AddImageflowAzureBlobService multiple times for each connection string

--- a/src/Imageflow.Server.Storage.S3/PrefixMapping.cs
+++ b/src/Imageflow.Server.Storage.S3/PrefixMapping.cs
@@ -1,3 +1,4 @@
+using System;
 using Amazon.S3;
 
 namespace Imageflow.Server.Storage.S3
@@ -5,7 +6,7 @@ namespace Imageflow.Server.Storage.S3
     internal struct PrefixMapping
     {
         internal string Prefix;
-        internal AmazonS3Config Config;
+        internal Func<IAmazonS3> ClientFactory;
         internal string Bucket;
         internal string BlobPrefix;
         internal bool IgnorePrefixCase;

--- a/src/Imageflow.Server.Storage.S3/S3Service.cs
+++ b/src/Imageflow.Server.Storage.S3/S3Service.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Amazon.Runtime;
 using Amazon.S3;
 using Imazen.Common.Storage;
 using Microsoft.Extensions.Logging;
@@ -13,19 +12,8 @@ namespace Imageflow.Server.Storage.S3
     {
         private readonly List<PrefixMapping> mappings = new List<PrefixMapping>();
 
-        private readonly AWSCredentials credentials;
         public S3Service(S3ServiceOptions options, ILogger<S3Service> logger)
         {
-
-            if (options.AccessKeyId == null)
-            {
-                credentials = new AnonymousAWSCredentials();
-            }
-            else
-            {
-                credentials = new  BasicAWSCredentials(options.AccessKeyId, options.SecretAccessKey);
-            }
-
             foreach (var m in options.Mappings)
             {
                 mappings.Add(m);;
@@ -66,7 +54,7 @@ namespace Imageflow.Server.Storage.S3
 
             try
             {
-                using var client = new AmazonS3Client(credentials, mapping.Config);
+                using var client = mapping.ClientFactory();
                 var req = new Amazon.S3.Model.GetObjectRequest() { BucketName = mapping.Bucket, Key = key };
 
                 var s = await client.GetObjectAsync(req);

--- a/src/Imageflow.Server.Storage.S3/S3ServiceOptions.cs
+++ b/src/Imageflow.Server.Storage.S3/S3ServiceOptions.cs
@@ -1,22 +1,31 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using Amazon;
+using Amazon.Runtime;
 using Amazon.S3;
 
 namespace Imageflow.Server.Storage.S3
 {
     public class S3ServiceOptions
     {
-
-        internal readonly string AccessKeyId;
-        internal readonly string SecretAccessKey;
+        private readonly AWSCredentials credentials;
         internal readonly List<PrefixMapping> Mappings = new List<PrefixMapping>();
+
+        public S3ServiceOptions()
+        {
+            credentials = new AnonymousAWSCredentials();
+        }
+
+        public S3ServiceOptions(AWSCredentials credentials)
+        {
+            this.credentials = credentials;
+        }
+
         public S3ServiceOptions(string accessKeyId, string secretAccessKey)
         {
-            this.AccessKeyId = accessKeyId;
-            this.SecretAccessKey = secretAccessKey;
+            credentials = accessKeyId == null
+                ? (AWSCredentials) new AnonymousAWSCredentials()
+                : new BasicAWSCredentials(accessKeyId, secretAccessKey);
         }
 
         public S3ServiceOptions MapPrefix(string prefix, RegionEndpoint region, string bucket)
@@ -30,9 +39,9 @@ namespace Imageflow.Server.Storage.S3
 
         public S3ServiceOptions MapPrefix(string prefix, RegionEndpoint region, string bucket, string blobPrefix,
             bool ignorePrefixCase, bool lowercaseBlobPath)
-            => MapPrefix(prefix, new AmazonS3Config() {RegionEndpoint = region}, bucket,
+            => MapPrefix(prefix, new AmazonS3Config() { RegionEndpoint = region }, bucket,
                 blobPrefix, ignorePrefixCase, lowercaseBlobPath);
- 
+
         /// <summary>
         /// Maps a given prefix to a specified location within a bucket
         /// </summary>
@@ -46,7 +55,27 @@ namespace Imageflow.Server.Storage.S3
         /// (requires that actual blobs all be lowercase).</param>
         /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
-        public S3ServiceOptions MapPrefix(string prefix, AmazonS3Config s3Config, string bucket, string blobPrefix, bool ignorePrefixCase, bool lowercaseBlobPath)
+        public S3ServiceOptions MapPrefix(string prefix, AmazonS3Config s3Config, string bucket, string blobPrefix,
+            bool ignorePrefixCase, bool lowercaseBlobPath)
+        {
+            Func<IAmazonS3> client = () => new AmazonS3Client(credentials, s3Config);
+            return MapPrefix(prefix, client, bucket, blobPrefix, ignorePrefixCase, lowercaseBlobPath);
+        }
+
+        /// <summary>
+        /// Maps a given prefix to a specified location within a bucket
+        /// </summary>
+        /// <param name="prefix">The prefix to capture image requests within</param>
+        /// <param name="s3ClientFactory">Lambda function to provide an instance of IAmazonS3, which will be disposed after use.</param>
+        /// <param name="bucket">The bucket to serve images from</param>
+        /// <param name="blobPrefix">The path within the bucket to serve images from. Can be an empty string to serve
+        /// from root of bucket.</param>
+        /// <param name="ignorePrefixCase">Whether to be cases sensitive about requests matching 'prefix'</param>
+        /// <param name="lowercaseBlobPath">Whether to lowercase all incoming paths to allow for case insensitivity
+        /// (requires that actual blobs all be lowercase).</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        public S3ServiceOptions MapPrefix(string prefix, Func<IAmazonS3> s3ClientFactory, string bucket, string blobPrefix, bool ignorePrefixCase, bool lowercaseBlobPath)
         {
             prefix = prefix.TrimStart('/').TrimEnd('/');
             if (prefix.Length == 0)
@@ -59,16 +88,16 @@ namespace Imageflow.Server.Storage.S3
 
             Mappings.Add(new PrefixMapping()
             {
-                Bucket=bucket, 
-                Prefix=prefix, 
-                Config=s3Config, 
+                Bucket = bucket,
+                Prefix = prefix,
+                ClientFactory = s3ClientFactory,
                 BlobPrefix = blobPrefix,
                 IgnorePrefixCase = ignorePrefixCase,
                 LowercaseBlobPath = lowercaseBlobPath
-                
+
             });
             return this;
         }
-        
+
     }
 }


### PR DESCRIPTION
As suggested in #43, this PR adds an overload to `MapPrefix` to supply an instance of `IAmazonS3` at execution time.